### PR TITLE
Record field lenses work on sum types, if all patterns have the field.

### DIFF
--- a/generic-lens.cabal
+++ b/generic-lens.cabal
@@ -53,7 +53,6 @@ library
 
   -- Other library packages from which modules are imported.
   build-depends:     base >= 4.9 && <= 5.0
-                   , profunctors
 
   -- Directories containing source files.
   hs-source-dirs:    src

--- a/generic-lens.cabal
+++ b/generic-lens.cabal
@@ -51,6 +51,7 @@ library
 
   -- Other library packages from which modules are imported.
   build-depends:     base >= 4.9 && <= 5.0
+                   , profunctors
 
   -- Directories containing source files.
   hs-source-dirs:    src

--- a/src/Data/Generics/Internal/Lens.hs
+++ b/src/Data/Generics/Internal/Lens.hs
@@ -16,7 +16,8 @@
 module Data.Generics.Internal.Lens where
 
 import Control.Applicative  ( Const (..) )
-import GHC.Generics         ( (:*:) (..), Generic (..), M1 (..), Rep )
+import GHC.Generics         ( (:*:) (..), Generic (..), M1 (..), Rep, (:+:) (..) )
+import Data.Profunctor      ( dimap, Choice (..) )
 
 -- | Identity functor
 newtype Identity a
@@ -30,6 +31,9 @@ instance Functor Identity where
 -- | Type alias for lens
 type Lens' s a
   = forall f. Functor f => (a -> f a) -> s -> f s
+
+type Prism' s a
+  = forall p f. (Choice p, Applicative f) => p a (f a) -> p s (f s)
 
 -- | Getting
 (^.) :: s -> ((a -> Const a a) -> s -> Const a s) -> a
@@ -49,6 +53,23 @@ first f (a :*: b)
 second :: Lens' ((a :*: b) x) (b x)
 second f (a :*: b)
   = fmap (a :*:) (f b)
+
+prism :: (a -> s) -> (s -> Either s a) -> Prism' s a
+prism bt seta = dimap seta (either pure (fmap bt)) . right'
+
+either' :: (f x -> c) -> (g x -> c) -> (:+:) f g x -> c
+either' f _ (L1 x) = f x
+either' _ g (R1 x) = g x
+
+firstMaybe :: Prism' ((a :+: b) x) (a x)
+firstMaybe = prism L1 (either' Right (Left . R1))
+
+secondMaybe :: Prism' ((a :+: b) x) (b x)
+secondMaybe = prism R1 (either' (Left . L1) Right)
+
+combine :: Lens' (s x) a -> Lens' (t x) a -> Lens' ((:+:) s t x) a
+combine sa _ f (L1 s) = fmap (\a -> L1 (set sa a s)) (f (s ^. sa))
+combine _ ta f (R1 t) = fmap (\a -> R1 (set ta a t)) (f (t ^. ta))
 
 -- | A type and its generic representation are isomorphic
 repIso :: Generic a => Lens' a (Rep a x)

--- a/src/Data/Generics/Internal/Lens.hs
+++ b/src/Data/Generics/Internal/Lens.hs
@@ -17,7 +17,6 @@ module Data.Generics.Internal.Lens where
 
 import Control.Applicative  ( Const (..) )
 import GHC.Generics         ( (:*:) (..), Generic (..), M1 (..), Rep, (:+:) (..) )
-import Data.Profunctor      ( dimap, Choice (..) )
 
 -- | Identity functor
 newtype Identity a
@@ -31,9 +30,6 @@ instance Functor Identity where
 -- | Type alias for lens
 type Lens' s a
   = forall f. Functor f => (a -> f a) -> s -> f s
-
-type Prism' s a
-  = forall p f. (Choice p, Applicative f) => p a (f a) -> p s (f s)
 
 -- | Getting
 (^.) :: s -> ((a -> Const a a) -> s -> Const a s) -> a
@@ -54,19 +50,6 @@ first f (a :*: b)
 second :: Lens' ((a :*: b) x) (b x)
 second f (a :*: b)
   = fmap (a :*:) (f b)
-
-prism :: (a -> s) -> (s -> Either s a) -> Prism' s a
-prism bt seta = dimap seta (either pure (fmap bt)) . right'
-
-either' :: (f x -> c) -> (g x -> c) -> (:+:) f g x -> c
-either' f _ (L1 x) = f x
-either' _ g (R1 x) = g x
-
-firstMaybe :: Prism' ((a :+: b) x) (a x)
-firstMaybe = prism L1 (either' Right (Left . R1))
-
-secondMaybe :: Prism' ((a :+: b) x) (b x)
-secondMaybe = prism R1 (either' (Left . L1) Right)
 
 combine :: Lens' (s x) a -> Lens' (t x) a -> Lens' ((:+:) s t x) a
 combine sa _ f (L1 s) = fmap (\a -> L1 (set sa a s)) (f (s ^. sa))

--- a/src/Data/Generics/Record/HasField.hs
+++ b/src/Data/Generics/Record/HasField.hs
@@ -118,6 +118,9 @@ class GHasField (field :: Symbol) (s :: Type -> Type) a | field s -> a where
 instance (GHasFieldProd field s s' a (Contains field s)) => GHasField field (s :*: s') a where
   glabel = prodLabel @field @_ @_ @_ @(Contains field s)
 
+instance (GHasField field s a, GHasField field s' a) => GHasField field (s :+: s') a where
+  glabel = combine (glabel @field @s) (glabel @field @s')
+
 instance GHasField field (S1 ('MetaSel ('Just field) p f b) (Rec0 a)) a where
   glabel = lensM . glabel @field
 

--- a/src/Data/Generics/Record/Internal/Contains.hs
+++ b/src/Data/Generics/Record/Internal/Contains.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -38,6 +36,8 @@ type family Contains (field :: Symbol) f :: Maybe Type where
     = 'Just t
   Contains field (f :*: g)
     = Contains field f <|> Contains field g
+  Contains field (f :+: g)
+    = Contains field f <&> Contains field g
   Contains field (S1 _ _)
     = 'Nothing
   Contains field (C1 m f)
@@ -56,4 +56,8 @@ type family Contains (field :: Symbol) f :: Maybe Type where
 type family (a :: Maybe k) <|> (b :: Maybe k) :: Maybe k where
   'Just x <|> _  = 'Just x
   _ <|> b = b
+
+type family (a :: Maybe k) <&> (b :: Maybe k) :: Maybe k where
+  'Just x <&> 'Just x  = 'Just x
+  _ <&> _ = 'Nothing
 


### PR DESCRIPTION
Additionally, lens and kan-extensions removed, you probably want to add them back when you end up using them.