### PR TITLE
Switch from ghc-proofs to inspection-testing

### DIFF
--- a/generic-lens.cabal
+++ b/generic-lens.cabal
@@ -68,7 +68,7 @@ test-suite generic-lens-test
 
   build-depends:      base          >= 4.9 && <= 5.0
                     , generic-lens
-                    , ghc-proofs >= 0.1.1
+                    , inspection-testing >= 0.1
 
   default-language:   Haskell2010
   ghc-options:        -Wall

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 - '.'
 
 extra-deps:
-- 'ghc-proofs-0.1.1'
+- 'inspection-testing-0.1'
 
 flags: {}
 


### PR DESCRIPTION
While ghc-proofs is a nice hack, it is actually unsuitable for
this kind of testing, as it optimizes the terms differently than GHC
(and more aggressivley). Therefore I have created the inspection-testing
package, which _really_ checks the output of GHC’s optimization
pipeline, and is equivalent to manually checking the output of
`-ddump-simpl`.

It turns out that the tests in the test suite do not pass with
GHC-8.0.2; I am not sure why that is. Insufficient inlining? CSE
failure? With GHC-8.2 we get the desired result.

I use CPP to disable the tests that do not work on GHC-8.0. If you can
get it to work again, then just remove the `#if` stanzas.