### PR TITLE
traverse + newtype bug

### DIFF
--- a/generic-lens.cabal
+++ b/generic-lens.cabal
@@ -97,7 +97,7 @@ test-suite generic-lens-test
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test
   main-is:            Spec.hs
-  other-modules:      Util Test24 Test25 Test40
+  other-modules:      Util Test24 Test25 Test40 TestX
 
   build-depends:      base          >= 4.9 && <= 5.0
                     , generic-lens
@@ -105,6 +105,7 @@ test-suite generic-lens-test
                     , profunctors
                     , inspection-testing >= 0.2
                     , HUnit
+                    , monoidal-containers
 
   default-language:   Haskell2010
   ghc-options:        -Wall
@@ -176,4 +177,3 @@ benchmark generic-lens-bench
 
   default-language:   Haskell2010
   ghc-options:        -Wall
-

--- a/test/TestX.hs
+++ b/test/TestX.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module TestX where
+
+import Data.Generics.Product
+import GHC.Generics
+import Control.Lens
+import Data.HashMap.Monoidal as HM
+
+newtype Res a = Res {
+  hm :: HM.MonoidalHashMap a String
+} deriving (Eq, Show)
+
+main :: IO ()
+main = do
+  let foo = Res (HM.fromList [(1, "foo"), (2, "bar")])
+  print $ foo ^.. (field @"hm").traverse


### PR DESCRIPTION
Fails to compile with

```
    • Couldn't match type ‘generic-lens-1.0.0.1:Data.Generics.Internal.Families.Changing.ReplaceArgs
                             (Res a0)
                             (generic-lens-1.0.0.1:Data.Generics.Internal.Families.Changing.Unify
                                b'0 (t0 b0))’
                     with ‘Res a0’  
        arising from a use of ‘field’
      The type variables ‘b'0’, ‘t0’, ‘b0’, ‘a0’ are ambiguous
    • In the first argument of ‘(.)’, namely ‘(field @"hm")’
      In the second argument of ‘(^..)’, namely
        ‘(field @"hm") . traverse’  
      In the second argument of ‘($)’, namely
        ‘foo ^.. (field @"hm") . traverse’
    • Relevant bindings include     
        foo :: Res a0 (bound at test/TestX.hs:20:7)
   |                                
21 |   print $ foo ^.. (field @"hm").traverse
   |                    ^^^^^^^^^^^ 
```

The same sample works with `makeFields`.