### PR TITLE
Fix examples-doctest to find generic-lens modules.

### DIFF
--- a/examples/doctest.hs
+++ b/examples/doctest.hs
@@ -2,5 +2,6 @@ import Test.DocTest
 main
   = doctest
       [ "-iexamples"
+      , "-isrc"
       , "examples/Biscuits.hs"
       ]


### PR DESCRIPTION
If generic-lens isn't already installed, the `import Data.Generics.Product` and `import Data.Generics.Sum` statements in examples/Biscuits.hs will fail to find those modules without this fix.