### PR TITLE
Expose `Data.Generics.Labels` module

### DIFF
--- a/generic-lens.cabal
+++ b/generic-lens.cabal
@@ -48,6 +48,8 @@ library
                     , Data.Generics.Internal.VL.Prism
                     , Data.Generics.Internal.VL.Iso
 
+                    , Data.Generics.Labels
+
   other-modules:      Data.Generics.Internal.Families
                     , Data.Generics.Internal.Families.Changing
                     , Data.Generics.Internal.Families.Collect


### PR DESCRIPTION
I needed this to throw out my dependency on `generic-lens-labels`. 