### PR TITLE
Add prisms to IsLabel instance

### DIFF
--- a/src/Data/Generics/Labels.hs
+++ b/src/Data/Generics/Labels.hs
@@ -1,11 +1,17 @@
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
-{-# OPTIONS_GHC -Wno-orphans       #-}
+{-# LANGUAGE AllowAmbiguousTypes    #-}
+{-# LANGUAGE CPP                    #-}
+{-# LANGUAGE ConstraintKinds        #-}
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE PolyKinds              #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE TypeOperators          #-}
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE UndecidableInstances   #-}
+{-# OPTIONS_GHC -Wno-orphans        #-}
 
 
 --------------------------------------------------------------------------------
@@ -17,20 +23,115 @@
 -- Stability   : experimental
 -- Portability : non-portable
 --
--- Provides an (orphan) IsLabel instance for field lenses.
+-- Provides an (orphan) IsLabel instance for field lenses and constructor prisms.
 -- Use at your own risk.
 --------------------------------------------------------------------------------
 
-module Data.Generics.Labels () where
+module Data.Generics.Labels (
+  -- * Orphan IsLabel Instance
+  -- $sec1
+    Field(..)
+  , Field'
+  , Constructor(..)
+  , Constructor'
+  ) where
 
 import Data.Generics.Product
+import Data.Generics.Sum
+import Data.Generics.Internal.VL.Lens  (Lens)
+import Data.Generics.Internal.VL.Prism (Prism)
+
+import Data.Profunctor    (Choice)
+import Data.Type.Bool     (type (&&))
+import Data.Type.Equality (type (==))
+
 import GHC.OverloadedLabels
+import GHC.TypeLits
 
 
-instance (HasField field s t a b, Functor f, sft ~ (s -> f t)) =>
-  IsLabel field ((a -> f b) -> sft) where
+-- $sec1
+-- An instance for creating lenses and prisms with @#identifiers@ from the
+-- @OverloadedLabels@ extension.  Note that since overloaded labels do not
+-- support symbols starting with capital letters, all prisms (which come from
+-- constructor names, which are capitalized) must be prefixed with an underscore
+-- (e.g. @#_ConstructorName@).
+--
+-- Morally:
+--
+-- @
+-- instance (HasField name s t a b) => IsLabel name (Lens s t a b) where ...
+-- @
+-- and
+--
+-- @
+-- instance (AsConstructor name s t a b) => IsLabel name (Prism s t a b) where ...
+-- @
+--
+-- Remember:
+--
+-- @
+-- type Lens = forall f. Functor f => (a -> f b) -> s -> f t
+--
+-- type Prism s t a b = forall p f. (Choice p, Applicative f) => p a (f b) -> p s (f t)
+-- @
+--
+-- The orphan instance is unavoidable if we want to work with
+-- lenses-as-functions (as opposed to a 'ReifiedLens'-like newtype).
+
+-- | 'Field' is morally the same as 'HasField', but it is constructed from an
+-- incoherent combination of 'HasField' and 'HasField''.  In this way, it can be
+-- seamlessly used in the 'IsLabel' instance even when dealing with data types
+-- that don't have 'Field' instances (like data instances).
+class Field name s t a b | s name -> a, t name -> b, s name b -> t, t name a -> s where
+  fieldLens :: Lens s t a b
+
+type Field' name s a = Field name s s a a
+
+instance {-# INCOHERENT #-} HasField name s t a b => Field name s t a b where
+  fieldLens = field @name
+
+instance {-# INCOHERENT #-} HasField' name s a => Field name s s a a where
+  fieldLens = field' @name
+
+-- | 'Constructor' is morally the same as 'AsConstructor', but it is constructed from an
+-- incoherent combination of 'AsConstructor' and 'AsConstructor''.  In this way, it can be
+-- seamlessly used in the 'IsLabel' instance even when dealing with data types
+-- that don't have 'Constructor' instances (like data instances).
+class Constructor name s t a b | name s -> a, name t -> b where
+  constructorPrism :: Prism s t a b
+
+type Constructor' name s a = Constructor name s s a a
+
+instance {-# INCOHERENT #-} AsConstructor name s t a b => Constructor name s t a b where
+  constructorPrism = _Ctor @name
+
+instance {-# INCOHERENT #-} AsConstructor' name s a => Constructor name s s a a where
+  constructorPrism = _Ctor' @name
+
+
+instance ( (CmpSymbol "_@" name == 'LT && CmpSymbol "_{" name == 'GT) ~ capital
+         , IsLabelHelper capital name p f s t a b
+         , pafb ~ p a (f b), psft ~ p s (f t)) => IsLabel name (pafb -> psft) where
 #if __GLASGOW_HASKELL__ >= 802
-  fromLabel = field @field
+  fromLabel = labelOutput @capital @name @p @f
 #else
-  fromLabel _ = field @field
+  fromLabel _ = labelOutput @capital @name @p @f
 #endif
+
+-- | This helper class allows us to customize the output type of the lens to be
+-- either 'Prism' or 'Lens' (by choosing appropriate @p@ and @f@) as well as to
+-- choose between whether we're dealing with a lens or a prism.  The choice is
+-- made by whether the @capital@ argument is true or false, which is determined by
+-- whether the symbol starts with an underscore followed by a capital letter
+-- (a check done in the 'IsLabel' instance above).  If so, then we're dealing
+-- with a constructor name, which should be a prism, and otherwise, it's a field
+-- name, so we have a lens.
+class IsLabelHelper capital name p f s t a b where
+  labelOutput :: p a (f b) -> p s (f t)
+
+instance (Functor f, Field name s t a b) => IsLabelHelper 'False name (->) f s t a b where
+  labelOutput = fieldLens @name
+
+instance ( Applicative f, Choice p, Constructor name s t a b
+         , name' ~ AppendSymbol "_" name) => IsLabelHelper 'True name' p f s t a b where
+  labelOutput = constructorPrism @name


### PR DESCRIPTION
This PR extends the optional `IsLabel` instance to provide prisms for constructors in addition to lenses for fields.  I debated whether to push this PR to `generic-lens-labels` or perhaps to just create a new repo (`generic-optics-labels`?), but I felt that this was the best home for this code.  Please let me know if you disagree.

## Field Access
Instead of writing `field @"foo"` to get a lens for the field `foo` for some data type, one merely needs to write `#foo`.  Furthermore, if the data type is part of a data instance, or otherwise has a `HasField'` instance but no `HasField` instance, the label `#foo` will still work.

Rather than using the `HasField` and `HasField'` classes, one can use the combined `Field` class, (which has the same structure as `HasField`) and the `Field'` type synonym. (Note that I believe this addresses Issue https://github.com/kcsongor/generic-lens/issues/64)

## Constructor Access
Instead of writing `_Ctor @"Foo"` to get a prism for the variant `Foo` of some data type, one merely needs to write `#_Foo`.  Note the need to include the underscore `_` between the `#` and the constructor name; this is because GHC does not currently support overloaded labels starting with capital letters.  For example, the data type
```haskell
data Options = OptionA | OptionB | OptionC
```
will have prisms `#_OptionA`, `#_OptionB`, and `#_OptionC`.

Likewise, rather than using the `AsConstructor` and `AsConstructor'` classes, one can use the combined `Constructor` class, (which has the same structure as `AsConstructor`) and the `Constructor'` type synonym.

## Notes

### Incoherent Instances
This PR uses incoherent instances to combine, e.g., `HasField` and `HasField'` into a single class so that labels can work for any field lens.  This is not exactly elegant, but I didn't find a better solution.

### Orphan Instance
The `IsLabel` instance is now gigantic as it's covering all `a -> b`.  This can cause conflicts with other libraries, but I think it's worth it for the convenience you get here.  As one of the maintainers of the extensible records package https://github.com/target/row-types, I already have overlapping `HasField` and `AsConstructor` instances for an upcoming `generic-lens-row-types` package, and I think it will be more convenient to use the `Data.Generics.Labels` here and have my library play nicely with it than to try to accommodate multiple different `IsLabel` instances.

### Label Comparison (and fields that start with underscores)
The `IsLabel` instance chooses between returning a prism vs returning a lens based on whether the first character in the symbol is an underscore.  This is not very elegant, but it works, and it has some questionable repercussions.  Notably, consider the following data type declaration:
```haskell
data Foo = Foo
  { _Foo :: Int
  , _bar :: Int
  }
```
In this case, the label `#_Foo` would be for the prism based on the `Foo` constructor, meaning that there is no generic lens for the `_Foo` field.  Furthermore, the label `#_bar` would also be interpreted as a prism and could not be used as a lens to the `_bar` field.  Thus, this system does not mesh nicely with data types whose field names start with underscores.

One could modify the approach in this PR to force labels to start with an underscore followed by a capital letter; this lets the label `#_bar` point to the `_bar` field, but it does not help with the `_Foo` field.  I chose not to do this because 1) I like the simplicity of an underscore always indicating a prism, and 2) with overlapping instances, one can make usable lowercase names for prisms.

### Exposing This Module
Obviously, this work doesn't make a lot of sense without PR https://github.com/kcsongor/generic-lens/pull/68 also going through.
