### PR TITLE
Better type errors for missing instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,9 @@ install:
       (cd "."; autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
-  - rm -rf "."/.ghc.environment.* "."/dist
+  - cabal build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
+  - cabal build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
+  - rm -rf "."/.ghc.environment.* "."/dist-newstyle
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
 # Here starts the actual work to be performed for the package under test;
@@ -70,26 +70,26 @@ install:
 script:
   # test that source-distributions can be generated
   - (cd "."; cabal sdist)
-  - mv "."/dist/generic-lens-*.tar.gz ${DISTDIR}/
+  - mv "."/dist-newstyle/sdist/generic-lens-*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR}
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
   - "echo 'packages: generic-lens-*/*.cabal' > cabal.project"
   - "echo 'write-ghc-environment-files: always' >> cabal.project"
   # this builds all libraries and executables (without tests/benchmarks)
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
+  - cabal build -w ${HC} --disable-tests --disable-benchmarks all
 
   # Build with installed constraints for packages in global-db
   - if $INSTALLED; then
-      echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh;
+      echo cabal build -w ${HC} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh;
     else echo "Not building with installed constraints"; fi
 
   # build & run tests, build benchmarks
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} all
-  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} all; fi
+  - cabal build -w ${HC} ${TEST} ${BENCH} all
+  - if [ "x$TEST" = "x--enable-tests" ]; then cabal test -w ${HC} ${TEST} all; fi
 
   # haddock
   - rm -rf ./dist-newstyle
-  - if $HADDOCK; then cabal new-haddock -w ${HC} --disable-tests --disable-benchmarks all; else echo "Skipping haddock generation";fi
+  - if $HADDOCK; then cabal haddock -w ${HC} --disable-tests --disable-benchmarks all; else echo "Skipping haddock generation";fi
 
 # REGENDATA ["generic-lens.cabal"]
 # EOF

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 ## 1.2.0.0
 - Add `HasTypesUsing` and `HasTypesCustom` for custom traversals (Lysxia)
+- Improve type errors when no Generic instance is defined
 
 ### Breaking API changes
 - 'HasType' now includes a reflexive case (Matt Parsons) so that every type 'contains' itself

--- a/generic-lens.cabal
+++ b/generic-lens.cabal
@@ -56,6 +56,7 @@ library
                     , Data.Generics.Internal.Families.Changing
                     , Data.Generics.Internal.Families.Collect
                     , Data.Generics.Internal.Families.Has
+                    , Data.Generics.Internal.Errors
                     , Data.Generics.Internal.Void
 
                     , Data.Generics.Sum.Internal.Constructors

--- a/src/Data/GenericLens/Internal.hs
+++ b/src/Data/GenericLens/Internal.hs
@@ -18,6 +18,7 @@ module Data.GenericLens.Internal
   , module Data.Generics.Internal.Families.Collect
   , module Data.Generics.Internal.Families.Has
   , module Data.Generics.Internal.Void
+  , module Data.Generics.Internal.Errors
 
   , module Data.Generics.Sum.Internal.Constructors
   , module Data.Generics.Sum.Internal.Typed
@@ -35,6 +36,7 @@ import Data.Generics.Internal.Families.Changing
 import Data.Generics.Internal.Families.Collect
 import Data.Generics.Internal.Families.Has
 import Data.Generics.Internal.Void
+import Data.Generics.Internal.Errors
 
 import Data.Generics.Sum.Internal.Constructors
 import Data.Generics.Sum.Internal.Typed

--- a/src/Data/Generics/Internal/Errors.hs
+++ b/src/Data/Generics/Internal/Errors.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE KindSignatures #-}
+
+-------------------------------------------------------------------------------
+---- |
+---- Module      :  Data.Generics.Internal.Errors
+---- Copyright   :  (C) 2019 Csongor Kiss
+---- License     :  BSD3
+---- Maintainer  :  Csongor Kiss <kiss.csongor.kiss@gmail.com>
+---- Stability   :  experimental
+---- Portability :  non-portable
+----
+---- Provide more legible type errors as described in
+---- (https://kcsongor.github.io/report-stuck-families/)[this blog post].
+-------------------------------------------------------------------------------
+
+module Data.Generics.Internal.Errors
+ ( NoGeneric
+ , Defined
+ , Defined_list
+
+ , QuoteType
+ , PrettyError
+ ) where
+
+import GHC.Generics
+import GHC.TypeLits
+import Data.Kind
+
+type family NoGeneric (a :: Type) (ctxt :: [ErrorMessage]) :: Constraint where
+  NoGeneric a ctxt = PrettyError ('Text "No instance for " ':<>: QuoteType (Generic a)
+                                   ': ctxt)
+type family PrettyError (ctxt :: [ErrorMessage]) :: k where
+  PrettyError '[] = TypeError ('Text "")
+  PrettyError (c ': cs) = TypeError ('Text "| " ':<>: c ':$$: PrettyLines cs)
+
+type family PrettyLines (ctxt :: [ErrorMessage]) :: ErrorMessage where
+  PrettyLines '[] = 'Text ""
+  PrettyLines (c ': cs) = 'Text "|   " ':<>: c ':$$: PrettyLines cs
+
+type family Defined (break :: Type -> Type) (err :: Constraint) (a :: k) :: k where
+  Defined Void1 _ _ = Any
+  Defined _ _     k = k
+
+type family Defined_list (break :: [*]) (err :: Constraint) (a :: k) :: k where
+  Defined_list '[Void] _ _ = Any
+  Defined_list _ _        k = k
+
+data Void1 a
+data Void
+type family Any :: k
+
+type family QuoteType (typ :: k) :: ErrorMessage where
+  QuoteType typ = 'Text "‘" ':<>: 'ShowType typ ':<>: 'Text "’"

--- a/src/Data/Generics/Product/Param.hs
+++ b/src/Data/Generics/Product/Param.hs
@@ -16,8 +16,8 @@
 -- |
 -- Module      : Data.Generics.Product.Param
 -- Copyright   : (C) 2018 Csongor Kiss
--- Maintainer  : Csongor Kiss <kiss.csongor.kiss@gmail.com>
 -- License     : BSD3
+-- Maintainer  : Csongor Kiss <kiss.csongor.kiss@gmail.com>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/src/Data/Generics/Product/Param.hs
+++ b/src/Data/Generics/Product/Param.hs
@@ -21,7 +21,7 @@
 -- Stability   : experimental
 -- Portability : non-portable
 --
--- Derive traversal over type parameters
+-- Derive traversals over type parameters
 --
 --------------------------------------------------------------------------------
 
@@ -39,6 +39,7 @@ import GHC.Generics
 import Data.Kind
 import Data.Generics.Internal.VL.Iso
 import Data.Generics.Internal.GenericN
+import Data.Generics.Internal.Errors
 
 class HasParam (p :: Nat) s t a b | p t a -> s, p s b -> t, p s -> a, p t -> b where
   param :: Applicative g => (a -> g b) -> s -> g t
@@ -47,6 +48,12 @@ instance
   ( GenericN s
   , GenericN t
   -- TODO: merge the old 'Changing' code with 'GenericN'
+  , Defined (Rep s)
+    (NoGeneric s
+      '[ 'Text "arising from a generic traversal of the type parameter at position " ':<>: QuoteType n
+       , 'Text "of type " ':<>: QuoteType a ':<>: 'Text " in " ':<>: QuoteType s
+       ])
+    (() :: Constraint)
   , s ~ Infer t (P n b 'PTag) a
   , t ~ Infer s (P n a 'PTag) b
   , Error ((ArgCount s) <=? n) n (ArgCount s) s

--- a/src/Data/Generics/Product/Subtype.hs
+++ b/src/Data/Generics/Product/Subtype.hs
@@ -41,6 +41,7 @@ import GHC.Generics (Generic (Rep, to, from) )
 import GHC.TypeLits (Symbol, TypeError, ErrorMessage (..))
 import Data.Kind (Type, Constraint)
 import Data.Generics.Internal.Profunctor.Lens hiding (set)
+import Data.Generics.Internal.Errors
 
 -- $setup
 -- == /Running example:/
@@ -114,6 +115,16 @@ instance
   , GSmash (Rep a) (Rep b)
   , GUpcast (Rep a) (Rep b)
   , ErrorUnless b a (CollectFieldsOrdered (Rep b) \\ CollectFieldsOrdered (Rep a))
+  , Defined (Rep a)
+    (NoGeneric a '[ 'Text "arising from a generic lens focusing on " ':<>: QuoteType b
+                  , 'Text "as a supertype of " ':<>: QuoteType a
+                  ])
+    (() :: Constraint)
+  , Defined (Rep b)
+    (NoGeneric b '[ 'Text "arising from a generic lens focusing on " ':<>: QuoteType b
+                  , 'Text "as a supertype of " ':<>: QuoteType a
+                  ])
+    (() :: Constraint)
   ) => Subtype b a where
     smash p b = to $ gsmash (from p) (from b)
     upcast    = to . gupcast . from

--- a/src/Data/Generics/Product/Typed.hs
+++ b/src/Data/Generics/Product/Typed.hs
@@ -40,6 +40,7 @@ import Data.Kind    (Constraint, Type)
 import GHC.Generics (Generic (Rep))
 import GHC.TypeLits (TypeError, ErrorMessage (..))
 import Data.Generics.Internal.Profunctor.Lens
+import Data.Generics.Internal.Errors
 
 -- $setup
 -- == /Running example:/
@@ -111,6 +112,9 @@ class HasType a s where
 instance
   ( Generic s
   , ErrorUnlessOne a s (CollectTotalType a (Rep s))
+  , Defined (Rep s)
+    (NoGeneric s '[ 'Text "arising from a generic lens focusing on a field of type " ':<>: QuoteType a])
+    (() :: Constraint)
   , GLens (HasTotalTypePSym a) (Rep s) (Rep s) a a
   ) => HasType a s where
 

--- a/src/Data/Generics/Sum/Typed.hs
+++ b/src/Data/Generics/Sum/Typed.hs
@@ -34,6 +34,7 @@ import Data.Kind
 import GHC.Generics
 import GHC.TypeLits (TypeError, ErrorMessage (..), Symbol)
 import Data.Generics.Sum.Internal.Typed
+import Data.Generics.Internal.Errors
 
 import Data.Generics.Internal.Families
 import Data.Generics.Internal.Void
@@ -109,6 +110,9 @@ instance
   , as ~ TupleToList a
   , ListTuple a as
   , GAsType (Rep s) as
+  , Defined (Rep s)
+    (NoGeneric s '[ 'Text "arising from a generic prism focusing on a constructor of type " ':<>: QuoteType a])
+    (() :: Constraint)
   ) => AsType a s where
 
   _Typed eta = prismRavel (prismPRavel (repIso . _GTyped @_ @as . tupled)) eta


### PR DESCRIPTION
Addresses #50. Based on the [stuck type family trick](http://kcsongor.github.io/report-stuck-families/) to report missing instances for `Generic` and `HasTypesCustom`.

At the moment, only the `Types` traversal is covered, so this is work in progress