### PR TITLE
Attempt to fix param traversal for deeper than one level of nesting

### DIFF
--- a/src/Data/Generics/Internal/Families/Changing.hs
+++ b/src/Data/Generics/Internal/Families/Changing.hs
@@ -107,15 +107,15 @@ type family ReplaceArgs (t :: k) (subs :: [Sub]) :: k where
   ReplaceArgs t '[] = t
   ReplaceArgs t ('Sub n arg ': ss) = ReplaceArgs (ReplaceArg t n arg) ss
 
-type family LookupParam (a :: k) (p :: Nat) :: Maybe Nat where
-  LookupParam (param (n :: Nat)) m = 'Nothing
-  LookupParam (a (_ (m :: Nat))) n = IfEq m n ('Just 0) (MaybeAdd (LookupParam a n) 1)
-  LookupParam (a _) n = MaybeAdd (LookupParam a n) 1
-  LookupParam a _ = 'Nothing
+type family LookupParam (a :: k) (p :: Nat) :: [Nat] where
+  LookupParam (param (n :: Nat)) m = '[]
+  LookupParam (a (_ (m :: Nat))) n = IfEq m n '[0] (IncHead (LookupParam a n))
+  LookupParam (a b) n = IfEq '[] (LookupParam b n) (IncHead (LookupParam a n)) (0 ': LookupParam b n)
+  LookupParam a _ = '[]
 
-type family MaybeAdd (a :: Maybe Nat) (b :: Nat) :: Maybe Nat where
-  MaybeAdd 'Nothing _  = 'Nothing
-  MaybeAdd ('Just a) b = 'Just (a + b)
+type family IncHead (a :: [k]) :: [k] where
+  IncHead '[] = '[]
+  IncHead (x ': xs) = ((x + 1) ': xs)
 
 type family IfEq (a :: k) (b :: k) (t :: l) (f :: l) :: l where
   IfEq a a t _ = t


### PR DESCRIPTION
(_**this is not intended to be merged as it is**_)

Here's is my attempt to fix generic param traversal deriving for deeper than one level of nesting (#88). I'm unable to write a `GHasParamRec` instance for an arbitrary level of nesting.  I've mentioned this in a comment in the code.

Any help or feedback is appreciated.