### PR TITLE
Fix AsType instances for Void

### DIFF
--- a/src/Data/Generics/Internal/Void.hs
+++ b/src/Data/Generics/Internal/Void.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE PolyKinds, EmptyCase #-}
 module Data.Generics.Internal.Void where
 
 {-
@@ -17,3 +17,12 @@ module Data.Generics.Internal.Void where
 data Void
 data Void1 a
 data Void2 a b
+
+absurd :: Void -> x
+absurd v = case v of
+
+absurd1 :: Void1 a -> x
+absurd1 v = case v of
+
+absurd2 :: Void2 a b -> x
+absurd2 v = case v of

--- a/src/Data/Generics/Sum/Typed.hs
+++ b/src/Data/Generics/Sum/Typed.hs
@@ -119,14 +119,10 @@ instance
   {-# INLINE[2] _Typed #-}
 
 -- See Note [Uncluttering type signatures]
-instance {-# OVERLAPPING #-} AsType a Void where
-  _Typed = undefined
-  injectTyped = undefined
-  projectTyped = undefined
-instance {-# OVERLAPPING #-} AsType Void a where
-  _Typed = undefined
-  injectTyped = undefined
-  projectTyped = undefined
+instance AsType Void a where
+  _Typed = prism absurd Left
+  injectTyped = absurd
+  projectTyped = const Nothing
 
 type family ErrorUnlessOne (a :: Type) (s :: Type) (ctors :: [Symbol]) :: Constraint where
   ErrorUnlessOne _ _ '[_]


### PR DESCRIPTION
* Remove the illegitimate `AsType a Void` instance.

* Make the `AsType Void a` instance total and make it propagate
  errors correctly.

Fixes #90