### PR TITLE
Give HasAny/AsAny the same VTA behavior on 8.6 and 8.8

### DIFF
--- a/src/Data/Generics/Product/Any.hs
+++ b/src/Data/Generics/Product/Any.hs
@@ -53,7 +53,7 @@ import Data.Generics.Product.Typed
 -- human = Human "Tunyasz" 50 "London"
 -- :}
 
-class HasAny (sel :: k) s t a b | s sel k -> a where
+class HasAny sel s t a b | s sel -> a where
   -- |A lens that focuses on a part of a product as identified by some
   --  selector. Currently supported selectors are field names, positions and
   --  unique types. Compatible with the lens package's 'Control.Lens.Lens'

--- a/src/Data/Generics/Sum/Any.hs
+++ b/src/Data/Generics/Sum/Any.hs
@@ -61,7 +61,7 @@ import Data.Generics.Internal.VL.Prism
 -- :}
 
 -- |Sums that have generic prisms.
-class AsAny (sel :: k) a s | s sel k -> a where
+class AsAny sel a s | s sel -> a where
   -- |A prism that projects a sum as identified by some selector. Currently
   --  supported selectors are constructor names and unique types. Compatible
   --  with the lens package's 'Control.Lens.Prism' type.


### PR DESCRIPTION
This applies the patch suggested in https://github.com/kcsongor/generic-lens/issues/84#issue-409586240. With this, the `doctest`s pass on both 8.6 and 8.8.

Fixes #84.