### PR TITLE
Fix inlining of lenses for data types with multiple constructors

### DIFF
--- a/generic-lens-core/src/Data/Generics/Internal/Profunctor/Lens.hs
+++ b/generic-lens-core/src/Data/Generics/Internal/Profunctor/Lens.hs
@@ -107,6 +107,7 @@ choosing l r = withLensPrim l (\getl setl ->
                                         Right v -> let (c, v') = getr v in (Right c, v')
                                 s = bimap setl setr . stron
                             in lens g s))
+{-# INLINE choosing #-}
 
 lens :: (s -> (c,a)) -> ((c,b) -> t) -> Lens s t a b
 lens get _set = dimap get _set . second'


### PR DESCRIPTION
Consider the following:

```haskell
data XXX
  = XXX1 { xxx :: Int }
  | XXX2 { xxx :: Int }
  deriving Generic

xxx_lhs, xxx_rhs :: XXX -> Int
xxx_lhs = view (field @"xxx")
xxx_rhs = xxx
```

`xxx_lhs` and `xxx_rhs` do not compile to the same core (see below), this PR fixes that.

```
        tests/Optics/Tests/Utils.hs:40:
        tests/Optics/Tests/Labels.hs:58:21: xxx_lhs ==- xxx_rhs failed:                   
            LHS:                                                                          
                xxx_lhs = xxx_lhs_sqvg `cast` <Co:8>                                      
                                                                                          
                lvl_srsz = \ v -> v                                                       
                                                                                          
                lvl_srsy = \ @ x v -> v                                                   
                                                                                          
                lvl_ssMf = \ _ eta_X8k -> eta_X8k                                         
                                                                                          
                lvl_ssMg = Store id lvl_ssMf                                              
                                                                                          
                lvl_ssMZ = \ v -> v                                                       
                                                                                          
                lvl_ssN0                                                                  
                  = \ @ p @ i $dStrong x1 ->                                              
                      dimap                                                               
                        ($p1Strong $dStrong)                                              
                        ($fGeneric1M3 `cast` <Co:51>)                                     
                        (lvl_ssMZ `cast` <Co:44>)                                         
                        (case $dStrong of                                                 
                         { C:Strong ww_sswf ww_sswq ww_sswr ww_ssws ww_sswt ->            
                         case ww_sswf of                                                  
                         { C:Profunctor ww_sswi ww_sswj ww_sswk ww_sswl ww_sswm ww_sswn   
                                        ww_sswo ->                                        
                         ww_sswi                                                          
                           ($fGeneric1M3 `cast` <Co:37>)                                  
                           (lvl_srsy `cast` <Co:27>)                                      
                           (ww_sswi (unK2 `cast` <Co:15>) (lvl_srsz `cast` <Co:10>) x1)   
                         }                                                                
                         })                                                               
                                                                                          
                lvl_ssN2                                                                  
                  = \ @ p @ i $dStrong x1 ->                                              
                      dimap                                                               
                        ($p1Strong $dStrong)                                              
                        ($fGeneric1M3 `cast` <Co:51>)                                     
                        (lvl_ssMZ `cast` <Co:44>)                                         
                        (case $dStrong of                                                 
                         { C:Strong ww_sswf ww_sswq ww_sswr ww_ssws ww_sswt ->            
                         case ww_sswf of                                                  
                         { C:Profunctor ww_sswi ww_sswj ww_sswk ww_sswl ww_sswm ww_sswn   
                                        ww_sswo ->
                         ww_sswi
                           ($fGeneric1M3 `cast` <Co:37>)
                           (lvl_srsy `cast` <Co:27>)
                           (ww_sswi (unK2 `cast` <Co:15>) (lvl_srsz `cast` <Co:10>) x1)
                         }
                         })
                
                lvl_ssN3 = choosing lvl_ssN0 lvl_ssN2 $fStrongStore
                
                lvl_ssN4 = lvl_ssN3 lvl_ssMg
                
                xxx_lhs_sqvg
                  = case lvl_ssN4 of { Store get set ->
                    (\ x ->
                       get
                         (case x of {
                            XXX1 g1 -> Left (g1 `cast` <Co:48>);
                            XXX2 g1 -> Right (g1 `cast` <Co:48>)
                          }))
                    `cast` <Co:16>
                    }
                
            RHS:
                xxx_rhs = $sel:xxx:XXX1
                
                $sel:xxx:XXX1
                  = \ ds_dpxO ->
                      case ds_dpxO of {
                        XXX1 ds_dpxP -> ds_dpxP;
                        XXX2 ds_dpxQ -> ds_dpxQ
                      }
```