### PR TITLE
Bring back support for GHC 8.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.9.20200125
+# version: 0.9.20200306
 #
 version: ~> 1.0
 language: c
@@ -32,8 +32,8 @@ jobs:
     - compiler: ghc-8.10.1
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.10.1","cabal-install-3.2"]}}
       os: linux
-    - compiler: ghc-8.8.1
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.8.1","cabal-install-3.0"]}}
+    - compiler: ghc-8.8.3
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.8.3","cabal-install-3.0"]}}
       os: linux
     - compiler: ghc-8.6.5
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.6.5","cabal-install-3.0"]}}
@@ -41,8 +41,8 @@ jobs:
     - compiler: ghc-8.4.4
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.4.4","cabal-install-3.0"]}}
       os: linux
-    - compiler: ghc-8.4.1
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.4.1","cabal-install-3.0"]}}
+    - compiler: ghc-8.2.2
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.2.2","cabal-install-3.0"]}}
       os: linux
   allow_failures:
     - compiler: ghc-8.10.1
@@ -101,7 +101,7 @@ install:
   - cat $CABALHOME/config
   - rm -fv cabal.project cabal.project.local cabal.project.freeze
   - travis_retry ${CABAL} v2-update -v
-  - (cd /tmp && ${CABAL} v2-install $WITHCOMPILER -j2 doctest --constraint='doctest ==0.16.2.*')
+  - if [ $HCNUMVER -ge 80400 ] ; then (cd /tmp && ${CABAL} v2-install $WITHCOMPILER -j2 doctest --constraint='doctest ==0.16.2.*') ; fi
   # Generate cabal.project
   - rm -rf cabal.project cabal.project.local cabal.project.freeze
   - touch cabal.project
@@ -119,8 +119,8 @@ install:
   - ${CABAL} v2-freeze $WITHCOMPILER ${TEST} ${BENCH}
   - "cat cabal.project.freeze | sed -E 's/^(constraints: *| *)//' | sed 's/any.//'"
   - rm  cabal.project.freeze
-  - ${CABAL} v2-build $WITHCOMPILER ${TEST} ${BENCH} --dep -j2 all
-  - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks --dep -j2 all
+  - travis_wait 40 ${CABAL} v2-build $WITHCOMPILER ${TEST} ${BENCH} --dep -j2 all
+  - travis_wait 40 ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks --dep -j2 all
 script:
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
   # Packaging...
@@ -153,9 +153,9 @@ script:
   # Testing...
   - ${CABAL} v2-test $WITHCOMPILER ${TEST} ${BENCH} all
   # Doctest...
-  - (cd ${PKGDIR_generic_lens_core} && doctest  src)
-  - (cd ${PKGDIR_generic_lens} && doctest  src)
-  - (cd ${PKGDIR_generic_optics} && doctest  src)
+  - if [ $HCNUMVER -ge 80400 ] ; then (cd ${PKGDIR_generic_lens_core} && doctest  src) ; fi
+  - if [ $HCNUMVER -ge 80400 ] ; then (cd ${PKGDIR_generic_lens} && doctest  src) ; fi
+  - if [ $HCNUMVER -ge 80400 ] ; then (cd ${PKGDIR_generic_optics} && doctest  src) ; fi
   # cabal check...
   - (cd ${PKGDIR_generic_lens_core} && ${CABAL} -vnormal check)
   - (cd ${PKGDIR_generic_lens} && ${CABAL} -vnormal check)
@@ -166,5 +166,5 @@ script:
   - rm -f cabal.project.local
   - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks all
 
-# REGENDATA ("0.9.20200125",["--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.9.20200306",["--config=cabal.haskell-ci","cabal.project"])
 # EOF

--- a/generic-lens-core/generic-lens-core.cabal
+++ b/generic-lens-core/generic-lens-core.cabal
@@ -17,7 +17,7 @@ maintainer:           kiss.csongor.kiss@gmail.com
 category:             Generics, Records, Lens
 build-type:           Simple
 cabal-version:        >= 1.10
-Tested-With:          GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.1, GHC == 8.10.1
+Tested-With:          GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1
 
 extra-source-files:   ChangeLog.md
 
@@ -56,7 +56,7 @@ library
 
                     , Data.Generics.Product.Internal.HList
 
-  build-depends:      base        >= 4.11 && < 5
+  build-depends:      base        >= 4.10 && < 5
                     , text        >= 1.2 && < 1.3
                     , indexed-profunctors >= 0.1 && < 1.0
 

--- a/generic-lens-core/src/Data/Generics/Internal/GenericN.hs
+++ b/generic-lens-core/src/Data/Generics/Internal/GenericN.hs
@@ -33,7 +33,7 @@ import GHC.Generics
 import GHC.TypeLits
 import Data.Coerce
 
-data family Param :: Nat -> j -> k
+data family Param :: Nat -> j -> Type
 
 newtype instance Param n (a :: Type)
   = StarParam { getStarParam :: a}

--- a/generic-lens-core/src/Data/Generics/Product/Internal/HList.hs
+++ b/generic-lens-core/src/Data/Generics/Product/Internal/HList.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes    #-}
 {-# LANGUAGE ConstraintKinds        #-}
+{-# LANGUAGE CPP                    #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs                  #-}
@@ -41,6 +42,10 @@ import GHC.Generics
 import Data.Profunctor.Indexed
 import Data.Generics.Internal.Profunctor.Lens
 import Data.Generics.Internal.Profunctor.Iso
+
+#if __GLASGOW_HASKELL__ == 802
+import Data.Semigroup (Semigroup(..))
+#endif
 
 data HList (as :: [Type]) where
   Nil :: HList '[]

--- a/generic-lens/generic-lens.cabal
+++ b/generic-lens/generic-lens.cabal
@@ -14,7 +14,7 @@ maintainer:           kiss.csongor.kiss@gmail.com
 category:             Generics, Records, Lens
 build-type:           Simple
 cabal-version:        >= 1.10
-Tested-With:          GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.1, GHC == 8.10.1
+Tested-With:          GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1
 
 extra-source-files:   examples/StarWars.hs
                     , examples/Examples.hs
@@ -44,7 +44,7 @@ library
                     , Data.Generics.Internal.VL.Prism
                     , Data.Generics.Internal.VL.Iso
 
-  build-depends:      base        >= 4.11 && < 5
+  build-depends:      base        >= 4.10 && < 5
                     , generic-lens-core == 2.0.0.0
                     , profunctors
                     , text        >= 1.2 && < 1.3
@@ -59,7 +59,7 @@ test-suite inspection-tests
   main-is:            Spec.hs
   other-modules:      Util Test24 Test88 Test25 Test40 Test62 Test63 CustomChildren
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base          >= 4.10 && <= 5.0
                     , generic-lens
                     , lens
                     , profunctors
@@ -74,7 +74,7 @@ test-suite generic-lens-bifunctor
   hs-source-dirs:     test
   main-is:            Bifunctor.hs
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base          >= 4.10 && <= 5.0
                     , generic-lens
                     , lens
                     , HUnit
@@ -87,7 +87,7 @@ test-suite generic-lens-syb-tree
   hs-source-dirs:     test/syb
   main-is:            Tree.hs
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base          >= 4.10 && <= 5.0
                     , generic-lens
                     , lens
                     , profunctors
@@ -97,6 +97,10 @@ test-suite generic-lens-syb-tree
   ghc-options:        -Wall
 
 test-suite doctests
+  -- type signatures have different order of constraints with 8.2
+  if impl(ghc < 8.4)
+    buildable: False
+
   default-language:   Haskell2010
   type:               exitcode-stdio-1.0
   ghc-options:        -threaded

--- a/generic-lens/test/Spec.hs
+++ b/generic-lens/test/Spec.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -O -fplugin Test.Inspection.Plugin #-}
+{-# OPTIONS_GHC -fplugin Test.Inspection.Plugin #-}
 {-# OPTIONS_GHC -dsuppress-all #-}
 
 {-# OPTIONS_GHC -funfolding-use-threshold=150 #-}

--- a/generic-optics/generic-optics.cabal
+++ b/generic-optics/generic-optics.cabal
@@ -14,7 +14,7 @@ maintainer:           kiss.csongor.kiss@gmail.com
 category:             Generics, Records, Lens
 build-type:           Simple
 cabal-version:        >= 1.10
-Tested-With:          GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.1, GHC == 8.10.1
+Tested-With:          GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1
 
 extra-source-files:   examples/StarWars.hs
                     , examples/Examples.hs
@@ -41,7 +41,7 @@ library
 
   other-modules:      Data.Generics.Internal.Optics
 
-  build-depends:      base        >= 4.11 && < 5
+  build-depends:      base        >= 4.10 && < 5
                     , generic-lens-core == 2.0.0.0
                     , optics-core >= 0.2 && < 1.0
                     , text        >= 1.2 && < 1.3
@@ -56,7 +56,7 @@ test-suite generic-optics-inspection-tests
   main-is:            Spec.hs
   other-modules:      Util Test24 Test88 Test25 Test40 Test62 Test63 CustomChildren
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base          >= 4.10 && <= 5.0
                     , generic-optics
                     , optics-core
                     , inspection-testing >= 0.2
@@ -70,7 +70,7 @@ test-suite generic-optics-bifunctor
   hs-source-dirs:     test
   main-is:            Bifunctor.hs
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base          >= 4.10 && <= 5.0
                     , generic-optics
                     , optics-core
                     , HUnit
@@ -83,7 +83,7 @@ test-suite generic-optics-syb-tree
   hs-source-dirs:     test/syb
   main-is:            Tree.hs
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base          >= 4.10 && <= 5.0
                     , generic-optics
                     , optics-core
                     , HUnit

--- a/generic-optics/test/Spec.hs
+++ b/generic-optics/test/Spec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -fplugin Test.Inspection.Plugin #-}
 {-# OPTIONS_GHC -dsuppress-all #-}
 
 {-# OPTIONS_GHC -funfolding-use-threshold=150 #-}


### PR DESCRIPTION
Changes needed for compilation with GHC 8.2.2 are minimal.

Tests also pass out of the box. The only thing that fails is a couple of doctests because the signatures are different:

```haskell
src/Data/Generics/Sum/Typed.hs:105: failure in expression `:t _Typed'
expected: _Typed
            :: (AsType a s, Choice p, Applicative f) => p a (f a) -> p s (f s)
 but got: _Typed
            :: (Applicative f, Choice p, AsType a s) => p a (f a) -> p s (f s)

src/Data/Generics/Sum/Typed.hs:114: failure in expression `:t _Typed @Int'
expected: _Typed @Int
            :: (AsType Int s, Choice p, Applicative f) =>
               p Int (f Int) -> p s (f s)
 but got: _Typed @Int
            :: (Applicative f, Choice p, AsType Int s) =>
               p Int (f Int) -> p s (f s)

src/Data/Generics/Sum/Subtype.hs:128: failure in expression `:t _Sub @Int'
expected: _Sub @Int
            :: (AsSubtype Int sup, Choice p, Applicative f) =>
               p Int (f Int) -> p sup (f sup)
 but got: _Sub @Int
            :: (Applicative f, Choice p, AsSubtype Int sup) =>
               p Int (f Int) -> p sup (f sup)

src/Data/Generics/Sum/Constructors.hs:133: failure in expression `:t _Ctor'
expected: _Ctor
            :: (AsConstructor ctor s t a b, Choice p, Applicative f) =>
               p a (f b) -> p s (f t)
 but got: _Ctor
            :: (Applicative f, Choice p, AsConstructor ctor s t a b) =>
               p a (f b) -> p s (f t)

src/Data/Generics/Product/Typed.hs:113: failure in expression `:t typed'
expected: typed :: (HasType a s, Functor f) => (a -> f a) -> s -> f s
 but got: typed :: (Functor f, HasType a s) => (a -> f a) -> s -> f s

src/Data/Generics/Product/Subtype.hs:121: failure in expression `:t super'
expected: super
            :: (Subtype sup sub, Functor f) => (sup -> f sup) -> sub -> f sub
 but got: super
            :: (Functor f, Subtype sup sub) => (sup -> f sup) -> sub -> f sub

src/Data/Generics/Product/Subtype.hs:128: failure in expression `:t super @Int'
expected: super @Int
            :: (Subtype Int sub, Functor f) => (Int -> f Int) -> sub -> f sub
 but got: super @Int
            :: (Functor f, Subtype Int sub) => (Int -> f Int) -> sub -> f sub

src/Data/Generics/Product/Positions.hs:132: failure in expression `:t position'
expected: position
            :: (HasPosition i s t a b, Functor f) => (a -> f b) -> s -> f t
 but got: position
            :: (Functor f, HasPosition i s t a b) => (a -> f b) -> s -> f t

src/Data/Generics/Product/Fields.hs:158: failure in expression `:t field'
expected: field
            :: (HasField field s t a b, Functor f) => (a -> f b) -> s -> f t
 but got: field
            :: (Functor f, HasField field s t a b) => (a -> f b) -> s -> f t

Examples: 153  Tried: 153  Errors: 0  Failures: 9
```

I'm not sure what to do about them (I made doctests of generic-lens not buildable on GHC 8.2.2 for now).