### PR TITLE
Expose `Data.Generics.Product.Internal.Subtype`

### DIFF
--- a/generic-lens-core/src/Data/GenericLens/Internal.hs
+++ b/generic-lens-core/src/Data/GenericLens/Internal.hs
@@ -26,6 +26,8 @@ module Data.GenericLens.Internal
   , module Data.Generics.Internal.Profunctor.Iso
   , module Data.Generics.Internal.Profunctor.Lens
   , module Data.Generics.Internal.Profunctor.Prism
+
+  , module Data.Generics.Product.Internal.Subtype
   ) where
 
 import Data.Generics.Internal.Families
@@ -40,3 +42,5 @@ import Data.Generics.Internal.GenericN
 import Data.Generics.Internal.Profunctor.Iso
 import Data.Generics.Internal.Profunctor.Lens
 import Data.Generics.Internal.Profunctor.Prism
+
+import Data.Generics.Product.Internal.Subtype

--- a/generic-lens-core/src/Data/Generics/Product/Internal/Subtype.hs
+++ b/generic-lens-core/src/Data/Generics/Product/Internal/Subtype.hs
@@ -29,8 +29,8 @@
 
 module Data.Generics.Product.Internal.Subtype
   ( Context
-  , gsmash
-  , gupcast
+  , GSmash (..)
+  , GUpcast (..)
   ) where
 
 import Data.Generics.Internal.Families


### PR DESCRIPTION
The `GUpcast` mechanism is extremely useful as an independent thing. Namely, I can turn reps into HLists, mess around with them, pair them into a cons list, and then "upcast" them back to the right shape.

This commit/PR saves me ever having to write this code myself, and for that, I'm extremely grateful.