### PR TITLE
GHC 9.0 compatibility

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+## 1.3.0.0
+- Support for GHC 9.0
+
 ## 1.2.0.1
 - Give HasAny/AsAny the same VTA behavior on 8.6 and 8.8 (Ryan Scott)
 

--- a/generic-lens.cabal
+++ b/generic-lens.cabal
@@ -1,5 +1,5 @@
 name:                 generic-lens
-version:              1.2.0.1
+version:              1.3.0.0
 synopsis:             Generically derive traversals, lenses and prisms.
 description:          This library uses GHC.Generics to derive efficient optics (traversals, lenses and prisms) for algebraic data types in a type-directed way, with a focus on good type inference and error messages when possible.
 
@@ -11,7 +11,7 @@ maintainer:           kiss.csongor.kiss@gmail.com
 category:             Generics, Records, Lens
 build-type:           Simple
 cabal-version:        >= 1.10
-Tested-With:          GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.1
+Tested-With:          GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.1, GHC == 8.10.3, GHC == 9.0.1
 
 extra-source-files:   ChangeLog.md
                     , examples/StarWars.hs

--- a/src/Data/Generics/Internal/Profunctor/Iso.hs
+++ b/src/Data/Generics/Internal/Profunctor/Iso.hs
@@ -75,11 +75,11 @@ fromIso l = withIso l $ \ sa bt -> iso bt sa
 {-# INLINE fromIso #-}
 
 iso :: (s -> a) -> (b -> t) -> Iso s t a b
-iso = dimap
+iso sa bt = dimap sa bt
 {-# INLINE iso #-}
 
 iso2isovl :: Iso s t a b -> VL.Iso s t a b
-iso2isovl _iso = withIso _iso VL.iso
+iso2isovl _iso = withIso _iso $ \ sa bt -> VL.iso sa bt
 {-# INLINE iso2isovl #-}
 
 withIso :: Iso s t a b -> ((s -> a) -> (b -> t) -> r) -> r

--- a/src/Data/Generics/Internal/Profunctor/Prism.hs
+++ b/src/Data/Generics/Internal/Profunctor/Prism.hs
@@ -64,10 +64,10 @@ match k = withPrism k $ \_ _match -> _match
 -- Prism stuff
 
 without' :: Prism s t a b -> Prism s t c d -> Prism s t (Either a c) (Either b d)
-without' k =
-  withPrism k  $ \bt _ k' ->
-  withPrism k' $ \dt setc ->
-    prism (either bt dt) $ \s -> fmap Right (setc s)
+without' k p =
+  (withPrism k  $ \bt _ k' ->
+   withPrism k' $ \dt setc ->
+     prism (either bt dt) $ \s -> fmap Right (setc s)) p
 {-# INLINE without' #-}
 
 withPrism :: APrism s t a b -> ((b -> t) -> (s -> Either t a) -> r) -> r

--- a/src/Data/Generics/Product/Internal/Constraints.hs
+++ b/src/Data/Generics/Product/Internal/Constraints.hs
@@ -59,7 +59,7 @@ instance
   gconstraints' f (R1 r) = R1 <$> gconstraints' @c f r
 
 instance c a => GHasConstraints' c (Rec0 a) where
-  gconstraints' = kIso
+  gconstraints' f = kIso f
 
 instance GHasConstraints' c f
   => GHasConstraints' c (M1 m meta f) where
@@ -98,7 +98,7 @@ instance GHasConstraints c V1 V1 where
   gconstraints _ = pure
 
 instance c a b => GHasConstraints c (Rec0 a) (Rec0 b) where
-  gconstraints = kIso
+  gconstraints f = kIso f
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This patch adds GHC 9.0 support relative to `generic-lens-1.2.0.1`.     
I'm still using this version of `generic-lens` as I make extensive use of constrained traversals, which were removed in the `2.0` release.

I couldn't find a suitable branch to apply this to, but this patch was done on top of e4f6890.