### PR TITLE
ci: use ubuntu 20.04

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:


### PR DESCRIPTION
18.04 no longer seems to be supported: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners