### PR TITLE
ghc 9.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -164,7 +164,7 @@ jobs:
           cabal-plan --version
       - name: install doctest
         run: |
-          $CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.20'
+          $CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest
           doctest --version
       - name: save cache (tools)
         uses: actions/cache/save@v3

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/haskell-CI/haskell-ci
+# For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.16
+# version: 0.17.20231112
 #
-# REGENDATA ("0.16",["--config=cabal.haskell-ci","github","cabal.project"])
+# REGENDATA ("0.17.20231112",["--config=cabal.haskell-ci","github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -23,24 +23,29 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:focal
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.8.1
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.8.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.6.3
             compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.6.3
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.4.8
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.4.8
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -56,44 +61,29 @@ jobs:
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.4.1
-            compilerKind: ghc
-            compilerVersion: 8.4.1
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME"
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          fi
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -105,20 +95,13 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
-
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
@@ -168,7 +151,7 @@ jobs:
       - name: cache (tools)
         uses: actions/cache/restore@v3
         with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-ea326311
+          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-932ae6b0
           path: ~/.haskell-ci-tools
       - name: install cabal-plan
         run: |
@@ -181,16 +164,16 @@ jobs:
           cabal-plan --version
       - name: install doctest
         run: |
-          $CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.21'
+          $CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.20'
           doctest --version
       - name: save cache (tools)
         uses: actions/cache/save@v3
         if: always()
         with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-ea326311
+          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-932ae6b0
           path: ~/.haskell-ci-tools
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -259,11 +242,11 @@ jobs:
       - name: doctest
         run: |
           cd ${PKGDIR_generic_lens_core} || false
-          doctest  -XHaskell2010 src
+          doctest  -XHaskell2010 -XTypeOperators src
           cd ${PKGDIR_generic_lens} || false
-          doctest  -XHaskell2010 src
+          doctest  -XHaskell2010 -XTypeOperators src
           cd ${PKGDIR_generic_optics} || false
-          doctest  -XHaskell2010 src
+          doctest  -XHaskell2010 -XTypeOperators src
       - name: cabal check
         run: |
           cd ${PKGDIR_generic_lens_core} || false

--- a/generic-lens-core/generic-lens-core.cabal
+++ b/generic-lens-core/generic-lens-core.cabal
@@ -1,3 +1,4 @@
+cabal-version:        >= 1.10
 name:                 generic-lens-core
 version:              2.2.1.0
 synopsis:             Generically derive traversals, lenses and prisms.
@@ -16,8 +17,17 @@ author:               Csongor Kiss
 maintainer:           kiss.csongor.kiss@gmail.com
 category:             Generics, Records, Lens
 build-type:           Simple
-cabal-version:        >= 1.10
-Tested-With:          GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.7, GHC == 9.4.4, GHC == 9.6.1
+
+tested-with:
+  GHC == 9.8.1
+  GHC == 9.6.3
+  GHC == 9.4.8
+  GHC == 9.2.8
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
 
 extra-source-files:   ChangeLog.md
 
@@ -57,7 +67,7 @@ library
                     , Data.Generics.Product.Internal.HList
 
   build-depends:      base        >= 4.11 && < 5
-                    , text        >= 1.2 && < 1.3 || >= 2.0 && < 2.1
+                    , text        >= 1.2 && < 1.3 || >= 2.0 && < 2.2
                     , indexed-profunctors >= 0.1 && < 1.0
 
   hs-source-dirs:     src
@@ -67,4 +77,3 @@ library
 source-repository head
   type:               git
   location:           https://github.com/kcsongor/generic-lens
-

--- a/generic-lens-core/generic-lens-core.cabal
+++ b/generic-lens-core/generic-lens-core.cabal
@@ -72,6 +72,7 @@ library
 
   hs-source-dirs:     src
   default-language:   Haskell2010
+  default-extensions: TypeOperators
   ghc-options:        -Wall
 
 source-repository head

--- a/generic-lens/generic-lens.cabal
+++ b/generic-lens/generic-lens.cabal
@@ -62,6 +62,7 @@ library
 
   hs-source-dirs:     src
   default-language:   Haskell2010
+  default-extensions: TypeOperators
   ghc-options:        -Wall
 
 test-suite inspection-tests

--- a/generic-lens/generic-lens.cabal
+++ b/generic-lens/generic-lens.cabal
@@ -1,3 +1,4 @@
+cabal-version:        >= 1.10
 name:                 generic-lens
 version:              2.2.2.0
 synopsis:             Generically derive traversals, lenses and prisms.
@@ -13,8 +14,18 @@ author:               Csongor Kiss
 maintainer:           kiss.csongor.kiss@gmail.com
 category:             Generics, Records, Lens
 build-type:           Simple
-cabal-version:        >= 1.10
-Tested-With:          GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.7, GHC == 9.4.4, GHC == 9.6.1
+
+tested-with:
+  GHC == 9.8.1
+  GHC == 9.6.3
+  GHC == 9.4.8
+  GHC == 9.2.8
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+
 
 extra-source-files:   examples/StarWars.hs
                     , examples/Examples.hs
@@ -47,7 +58,7 @@ library
   build-depends:      base        >= 4.11 && < 5
                     , generic-lens-core == 2.2.1.0
                     , profunctors
-                    , text        >= 1.2 && < 1.3 || >= 2.0 && < 2.1
+                    , text        >= 1.2 && < 1.3 || >= 2.0 && < 2.2
 
   hs-source-dirs:     src
   default-language:   Haskell2010
@@ -59,7 +70,7 @@ test-suite inspection-tests
   main-is:            Spec.hs
   other-modules:      Util Test24 Test88 Test25 Test40 Test62 Test63 CustomChildren
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base
                     , generic-lens
                     , lens
                     , profunctors
@@ -74,7 +85,7 @@ test-suite generic-lens-bifunctor
   hs-source-dirs:     test
   main-is:            Bifunctor.hs
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base
                     , generic-lens
                     , lens
                     , HUnit
@@ -87,7 +98,7 @@ test-suite generic-lens-syb-tree
   hs-source-dirs:     test/syb
   main-is:            Tree.hs
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base
                     , generic-lens
                     , lens
                     , profunctors

--- a/generic-optics/generic-optics.cabal
+++ b/generic-optics/generic-optics.cabal
@@ -58,6 +58,7 @@ library
 
   hs-source-dirs:     src
   default-language:   Haskell2010
+  default-extensions: TypeOperators
   ghc-options:        -Wall
 
 test-suite generic-optics-inspection-tests

--- a/generic-optics/generic-optics.cabal
+++ b/generic-optics/generic-optics.cabal
@@ -1,3 +1,4 @@
+cabal-version:        >= 1.10
 name:                 generic-optics
 version:              2.2.1.0
 synopsis:             Generically derive traversals, lenses and prisms.
@@ -13,8 +14,17 @@ author:               Csongor Kiss
 maintainer:           kiss.csongor.kiss@gmail.com
 category:             Generics, Records, Lens
 build-type:           Simple
-cabal-version:        >= 1.10
-Tested-With:          GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.7, GHC == 9.4.4, GHC == 9.6.1
+
+tested-with:
+  GHC == 9.8.1
+  GHC == 9.6.3
+  GHC == 9.4.8
+  GHC == 9.2.8
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
 
 extra-source-files:   examples/StarWars.hs
                     , examples/Examples.hs
@@ -44,7 +54,7 @@ library
   build-depends:      base        >= 4.11 && < 5
                     , generic-lens-core == 2.2.1.0
                     , optics-core >= 0.2 && < 1.0
-                    , text        >= 1.2 && < 1.3 || >= 2.0 && < 2.1
+                    , text        >= 1.2 && < 1.3 || >= 2.0 && < 2.2
 
   hs-source-dirs:     src
   default-language:   Haskell2010
@@ -56,7 +66,7 @@ test-suite generic-optics-inspection-tests
   main-is:            Spec.hs
   other-modules:      Util Test24 Test88 Test25 Test40 Test62 Test63 CustomChildren
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base
                     , generic-optics
                     , optics-core
                     , inspection-testing >= 0.2
@@ -70,7 +80,7 @@ test-suite generic-optics-bifunctor
   hs-source-dirs:     test
   main-is:            Bifunctor.hs
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base
                     , generic-optics
                     , optics-core
                     , HUnit
@@ -83,7 +93,7 @@ test-suite generic-optics-syb-tree
   hs-source-dirs:     test/syb
   main-is:            Tree.hs
 
-  build-depends:      base          >= 4.11 && <= 5.0
+  build-depends:      base
                     , generic-optics
                     , optics-core
                     , HUnit


### PR DESCRIPTION
- Allow text-2.1, add GHC 9.8 to Haskell CI
- Add `default-extensions: TypeOperators`

Published revisions allowing text-2.1 to Hackage.

Successful CI run at: https://github.com/andreasabel/generic-lens/actions/runs/6970602551