### PR TITLE
Add INLINE annotations to internal functions

### DIFF
--- a/generic-lens-core/src/Data/Generics/Internal/Profunctor/Iso.hs
+++ b/generic-lens-core/src/Data/Generics/Internal/Profunctor/Iso.hs
@@ -36,6 +36,7 @@ type Iso' s a = Iso s s a a
 -- | A type and its generic representation are isomorphic
 repIso :: (Generic a, Generic b) => Iso a b (Rep a x) (Rep b x)
 repIso = iso from to
+{-# INLINE repIso #-}
 
 -- | 'M1' is just a wrapper around `f p`
 --mIso :: Iso' (M1 i c f p) (f p)
@@ -61,9 +62,11 @@ sumIso = iso back forth
 
 prodIso :: Iso ((a :*: b) x) ((a' :*: b') x) (a x, b x) (a' x, b' x)
 prodIso = iso (\(a :*: b) -> (a, b)) (\(a, b) -> (a :*: b))
+{-# INLINE prodIso #-}
 
 assoc3 :: Iso ((a, b), c) ((a', b'), c') (a, (b, c)) (a', (b', c'))
 assoc3 = iso (\((a, b), c) -> (a, (b, c))) (\(a, (b, c)) -> ((a, b), c))
+{-# INLINE assoc3 #-}
 
 --------------------------------------------------------------------------------
 -- Iso stuff
@@ -79,8 +82,10 @@ iso sa bt = dimap sa bt
 withIso :: Iso s t a b -> ((s -> a) -> (b -> t) -> r) -> r
 withIso ai k = case ai (Exchange id id) of
   Exchange sa bt -> k sa bt
+{-# INLINE withIso #-}
 
 pairing :: Iso s t a b -> Iso s' t' a' b' -> Iso (s, s') (t, t') (a, a') (b, b')
 pairing f g = withIso f $ \ sa bt -> withIso g $ \s'a' b't' ->
   iso (bmap sa s'a') (bmap bt b't')
   where bmap f' g' (a, b) = (f' a, g' b)
+{-# INLINE pairing #-}

--- a/generic-lens-core/src/Data/Generics/Internal/Profunctor/Lens.hs
+++ b/generic-lens-core/src/Data/Generics/Internal/Profunctor/Lens.hs
@@ -39,14 +39,17 @@ ravel l pab = conv (l idLens) pab
   where
     conv :: ALens a b i s t -> Lens s t a b
     conv (ALens _get _set) = lens _get _set
+{-# INLINE ravel #-}
 
 -- | Setting
 set :: ((a -> b) -> s -> t) -> (s, b) -> t
 set f (s, b)
   = f  (const b) s
+{-# INLINE set #-}
 
 view :: Lens s s a a -> s -> a
 view l = withLensPrim l (\get _ -> snd . get)
+{-# INLINE view #-}
 
 --withLens :: Lens s t a b -> ((s -> a) -> ((s, b) -> t) -> r) -> r
 --ithLens l k =
@@ -57,6 +60,7 @@ withLensPrim :: Lens s t a b -> (forall c . (s -> (c,a)) -> ((c, b) -> t) -> r) 
 withLensPrim l k =
  case l idLens of
    ALens _get _set -> k _get _set
+{-# INLINE withLensPrim #-}
 
 idLens :: ALens a b i a b
 idLens = ALens (fork (const ()) id) snd
@@ -66,14 +70,17 @@ idLens = ALens (fork (const ()) id) snd
 first :: Lens ((a :*: b) x) ((a' :*: b) x) (a x) (a' x)
 first
   = lens (\(a :*: b) -> (b,a)) (\(b, a') -> a' :*: b)
+{-# INLINE first #-}
 
 -- | Lens focusing on the second element of a product
 second :: Lens ((a :*: b) x) ((a :*: b') x) (b x) (b' x)
 second
   = lens (\(a :*: b) -> (a,b)) (\(a, b') -> a :*: b')
+{-# INLINE second #-}
 
 fork :: (a -> b) -> (a -> c) -> a -> (b, c)
 fork f g a = (f a, g a)
+{-# INLINE fork #-}
 
 --------------------------------------------------------------------------------
 
@@ -82,21 +89,27 @@ data Coyoneda f b = forall a. Coyoneda (a -> b) (f a)
 instance Functor (Coyoneda f) where
   fmap f (Coyoneda g fa)
     = Coyoneda (f . g) fa
+  {-# INLINE fmap #-}
 
 inj :: Functor f => Coyoneda f a -> f a
 inj (Coyoneda f a) = fmap f a
+{-# INLINE inj #-}
 
 proj :: Functor f => f a -> Coyoneda f a
 proj fa = Coyoneda id fa
+{-# INLINE proj #-}
 
 (??) :: Functor f => f (a -> b) -> a -> f b
 fab ?? a = fmap ($ a) fab
+{-# INLINE (??) #-}
 
 assoc3L :: Lens ((a, b), c) ((a', b'), c') (a, (b, c)) (a', (b', c'))
 assoc3L f = assoc3 f
+{-# INLINE assoc3L #-}
 
 stron :: (Either s s', b) -> Either (s, b) (s', b)
 stron (e, b) =  bimap (,b) (, b) e
+{-# INLINE stron #-}
 
 choosing :: forall s t a b s' t' . Lens s t a b -> Lens s' t' a b -> Lens (Either s s') (Either t t') a b
 choosing l r = withLensPrim l (\getl setl ->
@@ -118,14 +131,19 @@ data ALens a b i s t = forall c . ALens (s -> (c,a)) ((c, b) -> t)
 
 instance Functor (ALens a b i s) where
   fmap f (ALens _get _set) = ALens _get (f . _set)
+  {-# INLINE fmap #-}
 
 instance Profunctor (ALens a b) where
   dimap f g (ALens get _set) = ALens (get . f) (g . _set)
+  {-# INLINE dimap #-}
   lmap f = dimap f id
+  {-# INLINE lmap #-}
   rmap f = dimap id f
+  {-# INLINE rmap #-}
 
 swap :: (a, b) -> (b, a)
 swap (x, y) = (y, x)
+{-# INLINE swap #-}
 
 instance Strong (ALens a b) where
   first' = dimap swap swap . second'

--- a/generic-lens-core/src/Data/Generics/Internal/Profunctor/Prism.hs
+++ b/generic-lens-core/src/Data/Generics/Internal/Profunctor/Prism.hs
@@ -34,27 +34,35 @@ type Prism' s a = forall p i . (Choice p) => p i a a -> p i s s
 
 left :: Prism ((a :+: c) x) ((b :+: c) x) (a x) (b x)
 left = prism L1 $ gsum Right (Left . R1)
+{-# INLINE left #-}
 
 right :: Prism ((a :+: b) x) ((a :+: c) x) (b x) (c x)
 right = prism R1 $ gsum (Left . L1) Right
+{-# INLINE right #-}
 
 prism :: (b -> t) -> (s -> Either t a) -> Prism s t a b
 prism bt seta eta = dimap seta (either id bt) (right' eta)
+{-# INLINE prism #-}
 
 _Left :: Prism (Either a c) (Either b c) a b
 _Left = left'
+{-# INLINE _Left #-}
 
 _Right :: Prism (Either c a) (Either c b) a b
 _Right = right'
+{-# INLINE _Right #-}
 
 prismPRavel :: APrism i s t a b -> Prism s t a b
 prismPRavel l pab = (prism2prismp $ l idPrism) pab
+{-# INLINE prismPRavel #-}
 
 build :: (Tagged i b b -> Tagged i t t) -> b -> t
 build p = unTagged #. p .# Tagged
+{-# INLINE build #-}
 
 match :: Prism s t a b -> s -> Either t a
 match k = withPrism k $ \_ _match -> _match
+{-# INLINE match #-}
 
 --------------------------------------------------------------------------------
 -- Prism stuff
@@ -69,13 +77,17 @@ without' k k' =
 withPrism :: APrism i s t a b -> ((b -> t) -> (s -> Either t a) -> r) -> r
 withPrism k f = case k idPrism of
   Market bt seta -> f bt seta
+{-# INLINE withPrism #-}
 
 prism2prismp :: Market a b i s t -> Prism s t a b
 prism2prismp (Market bt seta) = prism bt seta
+{-# INLINE prism2prismp #-}
 
 idPrism :: Market a b i a b
 idPrism = Market id Right
+{-# INLINE idPrism #-}
 
 gsum :: (a x -> c) -> (b x -> c) -> ((a :+: b) x) -> c
 gsum f _ (L1 x) =  f x
 gsum _ g (R1 y) =  g y
+{-# INLINE gsum #-}

--- a/generic-lens-core/src/Data/Generics/Internal/VL/Traversal.hs
+++ b/generic-lens-core/src/Data/Generics/Internal/VL/Traversal.hs
@@ -57,20 +57,28 @@ instance (Functor f) => Applicative (Curried f) where
 
 liftCurried :: Applicative f => f a -> Curried f a
 liftCurried fa = Curried (<*> fa)
+{-# INLINE liftCurried #-}
 
 lowerCurried :: Applicative f => Curried f a -> f a
 lowerCurried (Curried f) = f (pure id)
+{-# INLINE lowerCurried #-}
+
 newtype Yoneda f a = Yoneda { runYoneda :: forall b. (a -> b) -> f b }
 
 liftYoneda :: Functor f => f a -> Yoneda f a
 liftYoneda a = Yoneda (\f -> fmap f a)
+{-# INLINE liftYoneda #-}
 
 lowerYoneda :: Yoneda f a -> f a
 lowerYoneda (Yoneda f) = f id
+{-# INLINE lowerYoneda #-}
 
 instance Functor (Yoneda f) where
   fmap f m = Yoneda (\k -> runYoneda m (k . f))
+  {-# INLINE fmap #-}
 
 instance Applicative f => Applicative (Yoneda f) where
   pure a = Yoneda (\f -> pure (f a))
+  {-# INLINE pure #-}
   Yoneda m <*> Yoneda n = Yoneda (\f -> m (f .) <*> n id)
+  {-# INLINE (<*>) #-}

--- a/generic-lens-core/src/Data/Generics/Internal/Wrapped.hs
+++ b/generic-lens-core/src/Data/Generics/Internal/Wrapped.hs
@@ -50,6 +50,8 @@ class GWrapped s t a b | s -> a, t -> b, s b -> t, t a -> s where
 
 instance GWrapped s t a b => GWrapped (M1 i k s) (M1 i k t) a b where
   gWrapped = mIso . gWrapped
+  {-# INLINE gWrapped #-}
 
 instance (a ~ c, b ~ d) => GWrapped (K1 i a) (K1 i b) c d where
   gWrapped = kIso
+  {-# INLINE gWrapped #-}

--- a/generic-lens/src/Data/Generics/Internal/VL/Iso.hs
+++ b/generic-lens/src/Data/Generics/Internal/VL/Iso.hs
@@ -68,25 +68,32 @@ withIso ai k = case ai (Exchange id Identity) of
 -- | A type and its generic representation are isomorphic
 repIso :: (Generic a, Generic b) => Iso a b (Rep a x) (Rep b x)
 repIso = iso from to
+{-# INLINE repIso #-}
 
 repIsoN :: (GenericN a, GenericN b) => Iso a b (RepN a x) (RepN b x)
 repIsoN = iso fromN toN
+{-# INLINE repIsoN #-}
 
 paramIso :: Iso (Param n a) (Param n b) a b
 paramIso = iso getStarParam StarParam
+{-# INLINE paramIso #-}
 
 -- | 'M1' is just a wrapper around `f p`
 mIso :: Iso (M1 i c f p) (M1 i c g p) (f p) (g p)
 mIso = iso unM1 M1
+{-# INLINE mIso #-}
 
 kIso :: Iso (K1 r a p) (K1 r b p) a b
 kIso = iso unK1 K1
+{-# INLINE kIso #-}
 
 recIso :: Iso (Rec r a p) (Rec r b p) a b
 recIso = iso (unK1 . unRec) (Rec . K1)
+{-# INLINE recIso #-}
 
 prodIso :: Iso ((a :*: b) x) ((a' :*: b') x) (a x, b x) (a' x, b' x)
 prodIso = iso (\(a :*: b) -> (a, b)) (\(a, b) -> (a :*: b))
+{-# INLINE prodIso #-}
 
 iso :: (s -> a) -> (b -> t) -> Iso s t a b
 iso sa bt = dimap sa (fmap bt)

--- a/generic-lens/src/Data/Generics/Internal/VL/Lens.hs
+++ b/generic-lens/src/Data/Generics/Internal/VL/Lens.hs
@@ -38,21 +38,26 @@ type Lens s t a b
 
 view :: ((a -> Const a a) -> s -> Const a s) -> s -> a
 view l s = (^.) s l
+{-# INLINE view #-}
 
 -- | Getting
 (^.) :: s -> ((a -> Const a a) -> s -> Const a s) -> a
 s ^. l = getConst (l Const s)
 infixl 8 ^.
+{-# INLINE (^.) #-}
 
 infixr 4 .~
 (.~) :: ((a -> Identity b) -> s -> Identity t) -> b -> s -> t
 (.~) f b = runIdentity . f (Identity . const b)
+{-# INLINE (.~) #-}
 
 set :: Lens s t a b -> b -> s -> t
 set l x = l .~ x
+{-# INLINE set #-}
 
 over :: ((a -> Identity b) -> s -> Identity t) -> (a -> b) -> s -> t
 over = coerce
+{-# INLINE over #-}
 
 lens2lensvl :: ALens a b i s t -> Lens s t a b
 lens2lensvl (ALens _get _set) =
@@ -64,6 +69,7 @@ lens2lensvl (ALens _get _set) =
 ravel :: (ALens a b i a b -> ALens a b i s t)
       ->  Lens s t a b
 ravel l pab = (lens2lensvl $ l idLens) pab
+{-# INLINE ravel #-}
 
 
 lens :: (s -> a) -> (s -> b -> t) -> Lens s t a b


### PR DESCRIPTION
We were seeing `ravel`, `repIso`, `first` and `second` calls in our profiling logs. This cleaned up that clutter and improved performance by a small margin. All internal functions other than `choosing` seem to be small enough to be suitable for inlining.