### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/generic-lens-core/src/Data/Generics/Product/Internal/HList.hs
+++ b/generic-lens-core/src/Data/Generics/Product/Internal/HList.hs
@@ -58,14 +58,12 @@ instance Semigroup (HList '[]) where
 
 instance Monoid (HList '[]) where
   mempty  = Nil
-  mappend _ _ = Nil
 
 instance (Semigroup a, Semigroup (HList as)) => Semigroup (HList (a ': as)) where
   (x :> xs) <> (y :> ys) = (x <> y) :> (xs <> ys)
 
 instance (Monoid a, Monoid (HList as)) => Monoid (HList (a ': as)) where
   mempty = mempty :> mempty
-  mappend (x :> xs) (y :> ys) = mappend x y :> mappend xs ys
 
 class Elem (as :: [(k, Type)]) (key :: k) (i :: Nat) a | as key -> i a
 instance {-# OVERLAPPING #-} pos ~ 0 => Elem (a ': xs) key pos a


### PR DESCRIPTION
This appeases the -Wnoncanonical-monoid-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/semigroup-monoid