### PR TITLE
Bump version to 2.3.0.0; bump cabal-version to 2.0

### DIFF
--- a/generic-lens-core/ChangeLog.md
+++ b/generic-lens-core/ChangeLog.md
@@ -1,3 +1,6 @@
+## generic-lens-core-2.2.1.1 (2025-08-27)
+- GHC 9.14 compatibility
+
 ## generic-lens-core-2.2.1.0 (2022-01-22)
 - GHC 9.2 compatibility
 

--- a/generic-lens-core/ChangeLog.md
+++ b/generic-lens-core/ChangeLog.md
@@ -1,4 +1,4 @@
-## generic-lens-core-2.2.1.1 (2025-08-27)
+## generic-lens-core-2.3.0.0 (2025-08-27)
 - GHC 9.14 compatibility
 
 ## generic-lens-core-2.2.1.0 (2022-01-22)

--- a/generic-lens-core/generic-lens-core.cabal
+++ b/generic-lens-core/generic-lens-core.cabal
@@ -1,6 +1,6 @@
-cabal-version:        >= 1.10
+cabal-version:        2.0
 name:                 generic-lens-core
-version:              2.2.1.0
+version:              2.3.0.0
 synopsis:             Generically derive traversals, lenses and prisms.
 description:          This library uses GHC.Generics to derive efficient optics (traversals, lenses and prisms) for algebraic data types in a type-directed way, with a focus on good type inference and error messages when possible.
                       .
@@ -32,7 +32,7 @@ tested-with:
   GHC == 8.6.5
   GHC == 8.4.4
 
-extra-source-files:   ChangeLog.md
+extra-doc-files:      ChangeLog.md
 
 library
   exposed-modules:    Data.Generics.Internal.GenericN

--- a/generic-lens/ChangeLog.md
+++ b/generic-lens/ChangeLog.md
@@ -1,10 +1,14 @@
-## Unreleased
+## generic-lens-2.3.0.0 (2025-08-27)
+
+Tested with GHC 8.4 - 9.14 alpha1.
+
 - Add `OverloadedLabels` support for positional lenses, e.g. `#3` as an
   abbreviation for `position @3`, starting with GHC 9.6.
 
 ### Breaking API changes:
 - `AsType` now includes a reflexive case for consistency with `HasType`: every
   type can be treated 'as' itself.
+
 
 ## generic-lens-2.2.2.0 (2023-04-15)
 - Support unprefixed constructor prisms on GHC 9.6 (#152)
@@ -81,7 +85,7 @@
 
 - The type parameters of the classes have been changed to accommodate
   the type-changing update:
-  
+
   `class HasField name a s` -> `class HasField name s t a b` etc.
-  
+
   Accordingly, `field :: Lens' s a` -> `field :: Lens s t a b`

--- a/generic-lens/generic-lens.cabal
+++ b/generic-lens/generic-lens.cabal
@@ -1,6 +1,6 @@
-cabal-version:        >= 1.10
+cabal-version:        2.0
 name:                 generic-lens
-version:              2.2.2.0
+version:              2.3.0.0
 synopsis:             Generically derive traversals, lenses and prisms.
 description:          This library uses GHC.Generics to derive efficient optics (traversals, lenses and prisms) for algebraic data types in a type-directed way, with a focus on good type inference and error messages when possible.
                       .
@@ -32,7 +32,8 @@ tested-with:
 
 extra-source-files:   examples/StarWars.hs
                     , examples/Examples.hs
-                    , ChangeLog.md
+
+extra-doc-files:      ChangeLog.md
 
 library
   exposed-modules:    Data.Generics.Wrapped
@@ -59,7 +60,7 @@ library
                     , Data.Generics.Internal.VL.Iso
 
   build-depends:      base        >= 4.11 && < 5
-                    , generic-lens-core == 2.2.1.0
+                    , generic-lens-core ^>= 2.3.0.0
                     , profunctors
 
   hs-source-dirs:     src

--- a/generic-optics/ChangeLog.md
+++ b/generic-optics/ChangeLog.md
@@ -1,4 +1,6 @@
-## Unreleased
+## generic-optics-2.3.0.0 (2025-08-27)
+
+Tested with GHC 8.4 - 9.14 alpha1.
 
 ### Breaking API changes:
 - `AsType` now includes a reflexive case for consistency with `HasType`: every

--- a/generic-optics/generic-optics.cabal
+++ b/generic-optics/generic-optics.cabal
@@ -1,6 +1,6 @@
-cabal-version:        >= 1.10
+cabal-version:        2.0
 name:                 generic-optics
-version:              2.2.1.0
+version:              2.3.0.0
 synopsis:             Generically derive traversals, lenses and prisms.
 description:          This library uses GHC.Generics to derive efficient optics (traversals, lenses and prisms) for algebraic data types in a type-directed way, with a focus on good type inference and error messages when possible.
                       .
@@ -31,7 +31,8 @@ tested-with:
 
 extra-source-files:   examples/StarWars.hs
                     , examples/Examples.hs
-                    , ChangeLog.md
+
+extra-doc-files:      ChangeLog.md
 
 library
   exposed-modules:    Data.Generics.Wrapped
@@ -55,7 +56,7 @@ library
   other-modules:      Data.Generics.Internal.Optics
 
   build-depends:      base        >= 4.11 && < 5
-                    , generic-lens-core == 2.2.1.0
+                    , generic-lens-core ^>= 2.3.0.0
                     , optics-core >= 0.2 && < 1
 
   hs-source-dirs:     src


### PR DESCRIPTION
Candidates:
- http://hackage.haskell.org/package/generic-lens-core-2.2.1.1/candidate
- http://hackage.haskell.org/package/generic-lens-2.3.0.0/candidate
- http://hackage.haskell.org/package/generic-optics-2.3.0.0/candidate